### PR TITLE
Dockerfile auf 6.8.6 angepasst

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.4.3
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.8.6
 
-RUN bin/elasticsearch-plugin install -b https://distfiles.compuscene.net/elasticsearch/elasticsearch-prometheus-exporter-6.4.3.0.zip
-RUN bin/elasticsearch-plugin install -b com.floragunn:search-guard-6:6.4.3-23.1
+RUN bin/elasticsearch-plugin install -b https://github.com/vvanholl/elasticsearch-prometheus-exporter/releases/download/6.8.6.0/prometheus-exporter-6.8.6.0.zip
+RUN bin/elasticsearch-plugin install -b com.floragunn:search-guard-6:6.8.6-25.5
 
 # workaround to avoid file mounts
 RUN mkdir -p /usr/share/elasticsearch/config/overrides \


### PR DESCRIPTION
Neues Dockerfile zum taggen. Version nur auf 6.8.6 da SG keine höheren SG Versionen unterstützt. Prometheus Exporter gibt es auch nicht für 6.8.9 sonder nur bis 6.8.8

Angepasst auf die neue URI des Prometheus Exporters